### PR TITLE
Force OSRM release build on startup

### DIFF
--- a/bks/start_osrm.sh
+++ b/bks/start_osrm.sh
@@ -5,7 +5,10 @@
 
 set -e
 
+mkdir -p build
 cd build
+
+cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_ASSERTIONS=Off -DBUILD_TOOLS=Off -DENABLE_LTO=On
 
 make -j$(nproc) install
 


### PR DESCRIPTION
This avoids a handful of cases that assert in our routing graph that make it difficult to test OSRM changes.