### PR TITLE
Print out cases where `process_way` excludes a way

### DIFF
--- a/profiles/debug_way.lua
+++ b/profiles/debug_way.lua
@@ -36,9 +36,15 @@ end
 
 -- call the way function
 local result = {}
-Debug.process_way(way,result)
+return_value = Debug.process_way(way,result)
 
 -- print input and output
 pprint(way)
 print("=>")
 pprint(result)
+print("\nEnabled?")
+if return_value ~= nil then
+  pprint(return_value)
+else
+  print("true")
+end

--- a/profiles/lib/profile_debugger.lua
+++ b/profiles/lib/profile_debugger.lua
@@ -136,7 +136,8 @@ function Debug.process_way(way,result)
   Debug:reset_tag_fetch_counts()
   
    -- call the way processsing function
-  Debug.functions.process_way(Debug.profile,way,result)
+  return_value = Debug.functions.process_way(Debug.profile,way,result)
+  return return_value
 end
 
 return Debug


### PR DESCRIPTION
Print out whether the profile’s `process_way` excludes the way or not via a `return false` entry.