### PR TITLE
docker: add curl + ca-certificates + zstd to the runtime image

### DIFF
--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -52,13 +52,16 @@ COPY --from=builder /opt /opt
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends --no-install-suggests \
+        ca-certificates \
+        curl \
         expat \
         libboost-date-time1.81.0 \
         libboost-iostreams1.81.0 \
         libboost-program-options1.81.0 \
         libboost-thread1.81.0 \
         liblua5.4-0 \
-        libtbb12 && \
+        libtbb12 \
+        zstd && \
     rm -rf /var/lib/apt/lists/* && \
 # Add /usr/local/lib to ldconfig to allow loading libraries from there
     ldconfig /usr/local/lib


### PR DESCRIPTION
Adds `curl`, `ca-certificates`, and `zstd` to the `runstage` of `docker/Dockerfile-debian` (the `Dockerfile` symlink target) so the OSRM serving container can fetch its PBF over HTTPS with no extra image layer.

**Why:** the Bike Streets **Docker Swarm serving path** (replacing the per-droplet GitHub-Actions deploy) has the service `curl` the processed PBF at start — there's no host-side download step like the legacy compose flow. So the OSRM image itself needs:
- **`curl`** — download the PBF.
- **`ca-certificates`** — HTTPS to Spaces. This runstage uses `--no-install-recommends`, so (unlike the downstream `Dockerfile-osrm`, which gets it via recommends) it must be listed explicitly or curl fails on TLS.
- **`zstd`** — decompress a pre-built `.osrm.tar.zst` artifact (parity with the existing serving image; tiny).

**`awscli` intentionally omitted** — it's only used by the build/preprocess `aws s3 cp` upload, not by serving, and it's heavy (python + boto); that stays in the downstream build layer rather than bloating the canonical OSRM runtime image.

After this releases as a new `*-bks` image tag, point the Django app's `OSRM_SWARM_IMAGE` at it.